### PR TITLE
Update Sample Code to Use `x-square-hmacsha256-signature`

### DIFF
--- a/webhook-function/app.js
+++ b/webhook-function/app.js
@@ -19,7 +19,7 @@ exports.webhookFunction = async (event) => {
         TABLE_NAME,
         SIGNATURE_KEY, // This is set in the Parameter Store
     } = process.env;
-    const hmac = createHmac('sha1', SIGNATURE_KEY);
+    const hmac = createHmac('sha256', SIGNATURE_KEY);
     const requestUrl = `https://${
         event.requestContext.domainName + event.requestContext.path
     }`;
@@ -31,13 +31,13 @@ exports.webhookFunction = async (event) => {
         const hash = hmac.digest('base64');
 
         // Check if we have a valid webhook event
-        if(hash !== event.headers['x-square-signature']) {
+        if(hash !== event.headers['x-square-hmacsha256-signature']) {
             // We have an invalid webhook event.
             // Logging and stopping processing.
             console.error(`Mismatched request signature, ${
                 hash
             } !== ${
-                event.headers['x-square-signature']
+                event.headers['x-square-hmacsha256-signature']
             }`)
             throw new Error(`Mismatched request signature`);
         }
@@ -56,7 +56,7 @@ exports.webhookFunction = async (event) => {
         // Signal back to Square the event was received
         return {
             'statusCode': 200,
-            'body': "ok"
+            'body': '{"message": "hello world"}'
         }
     } catch (err) {
         console.error(err);

--- a/webhook-function/tests/unit/test-handler.js
+++ b/webhook-function/tests/unit/test-handler.js
@@ -7,7 +7,7 @@ var event, context;
 
 describe('Tests index', function () {
     it('verifies successful response', async () => {
-        const result = await app.lambdaHandler(event, context)
+        const result = await app.webhookFunction(event, context)
 
         expect(result).to.be.an('object');
         expect(result.statusCode).to.equal(200);


### PR DESCRIPTION
Resolves https://github.com/mootrichard/square-webhooks-sam-app/issues/1

The original code used `sha1` and the `x-square-signature` header, so I changed it to use `sha256` and the `x-square-hmacsha256-signature` header.

It is likely that using the `WebhooksHelper` from the Square Node.js SDK, as stated in the official documentation, would be ideal. However, that would require a complete rewrite of the code in this repository. Since I am not the code owner of this repository, so this pull request only changes the header being used.
https://developer.squareup.com/docs/webhooks/step3validate